### PR TITLE
Only fetch one result from GitHub API

### DIFF
--- a/bump-one.sh
+++ b/bump-one.sh
@@ -10,10 +10,10 @@ GET() {
 echo "bumping"
 pkg="$1"
 name=$(basename "$pkg")
-tag=$(GET https://api.github.com/repos/"$pkg"/tags | jshon -e 0)
+tag=$(GET https://api.github.com/repos/"$pkg"/tags?per_page=1 | jshon -e 0)
 version=$(jshon -e name -u <<<"$tag")
 taghash=$(jshon -e commit -e sha -u <<<"$tag")
-head=$(GET https://api.github.com/repos/"$pkg"/commits | jshon -e 0)
+head=$(GET https://api.github.com/repos/"$pkg"/commits?per_page=1 | jshon -e 0)
 headhash=$(jshon -e sha -u <<<"$head")
 
 echo "stable $version, master $headhash"


### PR DESCRIPTION
Since we are only interested in the first one anyway.

The default pagination returns 30 values.